### PR TITLE
adds tutorial-checklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.csv
+
 # files created when installing the github label sync tool (described in maintainer.md)
 node_modules
 package-lock.json
@@ -5,3 +7,53 @@ package.json
 
 # jupyter-book
 _build
+
+**/.ipynb_checkpoints
+
+.virtual_documents
+.DS_Store
+.vscode
+
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Pycharm
+/.idea
+
+.venv
+
+# Do not include test output
+/result_images/

--- a/_toc.yml
+++ b/_toc.yml
@@ -17,6 +17,7 @@ parts:
       - file: documentation/notebooks
       - file: documentation/build-doc
       - file: documentation/debugging
+      - file: documentation/tutorial-checklist
 
   - caption: Maintainer
     chapters:

--- a/documentation/notebooks.md
+++ b/documentation/notebooks.md
@@ -73,3 +73,7 @@ Then, close the file and open it as a notebook as shown in the [Editing an exist
 ```{important}
 Remember to add your notebook to `doc/_toc.yml` to ensure it's included in the documentation.
 ```
+
+```{tip}
+Before writing a tutorial, go over the [checklist.](tutorial-checklist.md)
+```

--- a/documentation/tutorial-checklist.md
+++ b/documentation/tutorial-checklist.md
@@ -1,0 +1,35 @@
+---
+jupytext:
+  notebook_metadata_filter: myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.5
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
++++ {"user_expressions": []}
+
+# Tutorial checklist
+
+```{note}
+This guidelines also apply to [blog posts](https://ploomber.io/blog/)
+```
+
+## Sample data must be publicly available
+
+Datasets must be available publicly so we can download them inline. In other words, you should be able to get a URL that when opened should take you to the raw data ([example](https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv)). Furthermore, the data should be available in a third-party site and not uploaded to any of our repositories.
+
+This will allow us to use is like this:
+
+```{code-cell} ipython3
+from urllib.request import urlretrieve
+import pandas as pd
+
+urlretrieve("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv", "penguins.csv")
+pd.read_csv("penguins.csv").head()
+```

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - python=3.10
   - pip
+  - pandas
   - pip:
     - jupyter-book
     # 0.13.2 is broken currently


### PR DESCRIPTION
Added a new document with the tutorial/blog post checklist. For now, it only states that datasets must be publicly available.

<!-- readthedocs-preview ploomber-contributing start -->
----
:books: Documentation preview :books:: https://ploomber-contributing--54.org.readthedocs.build/en/54/

<!-- readthedocs-preview ploomber-contributing end -->