### PR TITLE
Added clarification on where to mention Acceptance Criteria

### DIFF
--- a/contributing/process-outline.md
+++ b/contributing/process-outline.md
@@ -18,6 +18,7 @@ interested in working on.
 ## 2. Describe the Acceptance Criteria
 
 - Before starting to work on the issue, describe the acceptance criteria (AC). 
+- Write the AC in the issue when you create one.
 - The AC stage should be resolve in **24 hours** from issue assignment.
 - Describing the criteria includes what you're going to work on,
   and what the definition of done looks like (I'm going to add a function to  

--- a/contributing/process-outline.md
+++ b/contributing/process-outline.md
@@ -17,7 +17,7 @@ interested in working on.
 
 ## 2. Describe the Acceptance Criteria
 
-- Before starting to work on the issue, decide the acceptance criteria (AC)
+- Before starting to work on the issue, describe the acceptance criteria (AC)
   and add it to the issue. 
 - The AC stage should be resolve in **24 hours** from issue assignment.
 - Describing the criteria includes what you're going to work on,

--- a/contributing/process-outline.md
+++ b/contributing/process-outline.md
@@ -17,8 +17,8 @@ interested in working on.
 
 ## 2. Describe the Acceptance Criteria
 
-- Before starting to work on the issue, describe the acceptance criteria (AC). 
-- Write the AC in the issue when you create one.
+- Before starting to work on the issue, describe the acceptance criteria (AC)
+  and add it to the issue. 
 - The AC stage should be resolve in **24 hours** from issue assignment.
 - Describing the criteria includes what you're going to work on,
   and what the definition of done looks like (I'm going to add a function to  

--- a/contributing/process-outline.md
+++ b/contributing/process-outline.md
@@ -17,7 +17,7 @@ interested in working on.
 
 ## 2. Describe the Acceptance Criteria
 
-- Before starting to work on the issue, describe the acceptance criteria (AC)
+- Before starting to work on the issue, decide the acceptance criteria (AC)
   and add it to the issue. 
 - The AC stage should be resolve in **24 hours** from issue assignment.
 - Describing the criteria includes what you're going to work on,


### PR DESCRIPTION
Added where to include the Acceptance Criteria to avoid confusion.

<!-- readthedocs-preview ploomber-contributing start -->
----
:books: Documentation preview :books:: https://ploomber-contributing--85.org.readthedocs.build/en/85/

<!-- readthedocs-preview ploomber-contributing end -->